### PR TITLE
Support for scraping multiple mysqld hosts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,11 @@ STATICCHECK_IGNORE =
 
 DOCKER_IMAGE_NAME ?= mysqld-exporter
 
-test-docker:
-	@echo ">> testing docker image"
-	./test_image.sh "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" 9104
+test-docker-single-exporter:
+	@echo ">> testing docker image for single exporter"
+	./test_image_single_exporter.sh "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" 9104
 
+test-docker-multi-exporter:
+	@echo ">> testing docker image for mutli exporter"
+	./test_image_multi_exporter.sh "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" 9104
 .PHONY: test-docker

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ test-docker-single-exporter:
 	./test_image_single_exporter.sh "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" 9104
 
 test-docker-multi-exporter:
-	@echo ">> testing docker image for mutli exporter"
+	@echo ">> testing docker image for multi exporter"
 	./test_image_multi_exporter.sh "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" 9104
 .PHONY: test-docker

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ NOTE: It is recommended to set a max connection limit for the user to avoid over
 
 ### Running
 
+#####  Single exporter mode
+
 Running using an environment variable:
 
     export DATA_SOURCE_NAME='user:password@(hostname:3306)/'
@@ -39,6 +41,42 @@ Running using ~/.my.cnf:
 
     ./mysqld_exporter <flags>
 
+#####  Multi exporter mode
+This mode can be useful in monitoring MySQL deployments in cloud like RDS.
+
+
+    ./mysqld_exporter --export-multi-hosts --config-multi-hosts=<path to ini config file>
+ 
+Sample config file for multi exporter mode
+
+        [client]
+        user = foo
+        password = foo123
+        [client.server1]
+        user = bar
+        password = bar123
+        [client.server2]
+        user = bar1
+        password = bar1123
+
+On the prometheus side you can set a scrape config as follows
+
+        - job_name: mysql # To get metrics about the mysql exporter’s targets
+          static_configs:
+            - targets:
+              # All rds hostnames to monitor. The target(s) here is also used to figure out the client name from the multi host config.
+              - server1:3306
+              - server2:3306
+          relabel_configs:
+            - source_labels: [__address__]
+              target_label: __param_target
+            - source_labels: [__param_target]
+              target_label: instance
+            - target_label: __address__
+              # The mysqld_exporter host:port
+              replacement: localhost:9104
+
+#####  Flag format
 Example format for flags for version > 0.10.0:
 
     --collect.auto_increment.columns
@@ -105,6 +143,8 @@ exporter.log_slow_filter                   | Add a log_slow_filter to avoid slow
 web.listen-address                         | Address to listen on for web interface and telemetry.
 web.telemetry-path                         | Path under which to expose metrics.
 version                                    | Print the version information.
+export-multi-hosts                         | Enable multi exporter mode. Useful in monitoring MySQL deployments in cloud like RDS.
+config-multi-hosts                         | Path to the ini file used in multi exporter mode
 
 ### Setting the MySQL server's data source name
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,6 @@ NOTE: It is recommended to set a max connection limit for the user to avoid over
 
 #####  Single exporter mode
 
-Running using an environment variable:
-
-    export DATA_SOURCE_NAME='user:password@(hostname:3306)/'
-    ./mysqld_exporter <flags>
-
 Running using ~/.my.cnf:
 
     ./mysqld_exporter <flags>
@@ -167,8 +162,6 @@ ssl-key=/path/to/ssl/client/key
 ssl-cert=/path/to/ssl/client/cert
 ```
 
-Customizing the SSL configuration is only supported in the mysql cnf file and is not supported if you set the mysql server's data source name in the environment variable DATA_SOURCE_NAME.
-
 
 ## Using Docker
 
@@ -180,11 +173,23 @@ For example:
 docker network create my-mysql-network
 docker pull prom/mysqld-exporter
 
+1. Single exporter mode
+
 docker run -d \
   -p 9104:9104 \
   --network my-mysql-network  \
-  -e DATA_SOURCE_NAME="user:password@(hostname:3306)/" \
   prom/mysqld-exporter
+  --config.my-cnf=<path_to_cnf>
+
+2. Multi exporter mode
+
+docker run -d \
+  -p 9104:9104 \
+  --network my-mysql-network  \
+  prom/mysqld-exporter
+  --export-multi-hosts
+  --config-multi-hosts==<path_to_multi_exporter_cnf>
+
 ```
 
 ## heartbeat

--- a/config_multi_host.go
+++ b/config_multi_host.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+    "errors"
+    "fmt"
+    "os"
+    "gopkg.in/yaml.v2"
+)
+
+var (
+    errUserIsNotSet = errors.New("Field 'User' must exist and cannot be empty")
+    errNameIsNotSet = errors.New("Field 'Name' must exist and cannot be empty")
+    errPasswordIsNotSet = errors.New("Field 'Password' must exist and cannot be empty")
+    errPortIsNotSet = errors.New("Field 'Port' must exist and cannot be empty")
+
+)
+
+//multiHostExporterconfig is the struct containing MySQL connection info.
+type multiHostExporterConfig struct{
+    Clients []Client `yaml:"clients"`
+}
+
+type Client struct {
+    Name        string `yaml:"name"`
+    User        string `yaml:"user"`
+    Password    string `yaml:"password"`
+    Port        int    `yaml:"port"`
+    SSLCA       string `yaml:"ssl-ca"`
+    SSLCert     string `yaml:"ssl-cert"`
+    SSLKey      string `yaml:"ssl-key"`
+}
+
+// newMultiHostExporterConfig returns a new decoded multiHostExporterConfig struct
+func newMultiHostExporterConfig(configPath string) (*multiHostExporterConfig, error) {
+    c := &multiHostExporterConfig{}
+
+    f, err := os.Open(configPath)
+    if err != nil {
+        return nil, err
+    }
+    defer f.Close()
+
+    d := yaml.NewDecoder(f)
+    if err := d.Decode(&c); err != nil {
+        return nil, err
+    }
+
+    return c, nil
+}
+
+
+// validate validates the multi host config
+func (c multiHostExporterConfig) validate() error {
+	for _, client := range c.Clients {
+        if client.Name == "" {
+		    return errNameIsNotSet
+	    }
+        if client.User == "" {
+		    return errUserIsNotSet
+	    }
+        if client.Password == "" {
+		    return errPasswordIsNotSet
+	    }
+        if client.Port == 0 {
+		    return errPortIsNotSet
+	    }
+    }
+	return nil
+}
+
+// formDSN returns a dsn for a given host in multi host exporter mode
+func (c multiHostExporterConfig) formDSN(h string) (string, error) {
+    var dsn string
+    var default_client_index *int
+    for i, client := range c.Clients {
+        // Store the default_client index which could be of use later
+        if client.Name == "default_client" {
+            ind := i
+            default_client_index = &ind
+        } else if client.Name == h {
+            dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/", client.User, client.Password, h, client.Port)
+            if client.SSLCA != "" {
+                if tlsErr := customizeTLS(client.SSLCA, client.SSLCert, client.SSLKey); tlsErr != nil {
+                    tlsErr = fmt.Errorf("failed to register a custom TLS configuration for mysql dsn: %s", tlsErr)
+                    return dsn, tlsErr
+                }
+                dsn = fmt.Sprintf("%s?tls=custom", dsn)
+            }
+            return dsn, nil
+        }
+    }
+    // Could not find host specific client config. Try default_client
+    if default_client_index != nil {
+        dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/", c.Clients[*default_client_index].User, c.Clients[*default_client_index].Password, h, c.Clients[*default_client_index].Port)
+        client := c.Clients[*default_client_index]
+        if client.SSLCA != "" {
+            if tlsErr := customizeTLS(client.SSLCA, client.SSLCert, client.SSLKey); tlsErr != nil {
+                tlsErr = fmt.Errorf("failed to register a custom TLS configuration for mysql dsn: %s", tlsErr)
+                return dsn, tlsErr
+            }
+            dsn = fmt.Sprintf("%s?tls=custom", dsn)
+        }
+        return dsn, nil
+    }
+    return "", errors.New("Can't form dsn. Didn't find default client or host specific client")
+}

--- a/config_multi_host_test.go
+++ b/config_multi_host_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+    "testing"
+    "gopkg.in/yaml.v2"
+
+    "github.com/smartystreets/goconvey/convey"
+)
+
+func TestValidate(t *testing.T) {
+    const (
+        missingName = `
+            clients:
+            - user: blah
+              password: abc123
+              port: 3306
+            `
+         missingUser = `
+            clients:
+            - name: default_client
+              password: abc123
+              port: 3306
+            `
+         missingPassword = `
+            clients:
+            - name: default_client
+              user: blah
+              port: 3306
+            `
+        missingPort = `
+            clients:
+            - name: default_client
+              user: blah
+              password: abc123
+            `
+    )
+    convey.Convey("Various multi-host exporter config validation", t, func() {
+        convey.Convey("Client without name", func() {
+            c := &multiHostExporterConfig{}
+            err :=  yaml.Unmarshal([]byte(missingName), &c)
+            if err != nil {
+                t.Error(err)
+            }
+            err = c.validate()
+            convey.So(err, convey.ShouldResemble, errNameIsNotSet)
+        })
+        convey.Convey("Client without user", func() {
+            c := &multiHostExporterConfig{}
+            err :=  yaml.Unmarshal([]byte(missingUser), &c)
+            if err != nil {
+                t.Error(err)
+            }
+            err = c.validate()
+            convey.So(err, convey.ShouldResemble, errUserIsNotSet)
+        })
+        convey.Convey("Client without password", func() {
+            c := &multiHostExporterConfig{}
+            err :=  yaml.Unmarshal([]byte(missingPassword), &c)
+            if err != nil {
+                t.Error(err)
+            }
+            err = c.validate()
+            convey.So(err, convey.ShouldResemble, errPasswordIsNotSet)
+        })
+        convey.Convey("Client without port", func() {
+            c := &multiHostExporterConfig{}
+            err :=  yaml.Unmarshal([]byte(missingPort), &c)
+            if err != nil {
+                t.Error(err)
+            }
+            err = c.validate()
+            convey.So(err, convey.ShouldResemble, errPortIsNotSet)
+        })
+
+    })
+}
+
+
+func TestFormDSN(t *testing.T) {
+    const (
+        workingClient = `
+            clients:
+            - name: default_client
+              user: default_user
+              password: default_pass
+              port: 3306
+            - name: rds.example.com
+              user: rds_user
+              password: rds_pass
+              port: 8000
+        `
+    )
+    convey.Convey("Multi Host exporter dsn", t, func() {
+        convey.Convey("Default Client", func() {
+            c := &multiHostExporterConfig{}
+            err :=  yaml.Unmarshal([]byte(workingClient), &c)
+            if err != nil {
+                t.Error(err)
+            }
+            dsn, _ := c.formDSN("rds2.example.com")
+            convey.So(dsn, convey.ShouldEqual, "default_user:default_pass@tcp(rds2.example.com:3306)/")
+        })
+        convey.Convey("Host specific Client", func() {
+            c := &multiHostExporterConfig{}
+            err :=  yaml.Unmarshal([]byte(workingClient), &c)
+            if err != nil {
+                t.Error(err)
+            }
+            dsn, _ := c.formDSN("rds.example.com")
+            convey.So(dsn, convey.ShouldEqual, "rds_user:rds_pass@tcp(rds.example.com:8000)/")
+        })
+
+    })
+}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/ini.v1 v1.57.0
-	gopkg.in/yaml.v2 v2.2.5
 )
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/ini.v1 v1.57.0
+	gopkg.in/yaml.v2 v2.2.5
 )
 
 go 1.13

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -60,16 +60,16 @@ var (
 		"tls.insecure-skip-verify",
 		"Ignore certificate and server verification when using a tls connection.",
 	).Bool()
-    multiHostExporter = kingpin.Flag(
-        "export-multi-hosts",
-        "Setting it to true enables scraping multiple mysql hosts.",
-    ).Default("false").Bool()
-    multiHostExporterConfigFile = kingpin.Flag(
-        "config-multi-hosts",
-        "Path to yaml config file to fetch mysql client info. Used when export-multi-hosts is true.",
-    ).Default("config-multi.yml").String()
+	multiHostExporter = kingpin.Flag(
+		"export-multi-hosts",
+		"Setting it to true enables scraping multiple mysql hosts.",
+	).Default("false").Bool()
+	multiHostExporterConfigFile = kingpin.Flag(
+		"config-multi-hosts",
+		"Path to yaml config file to fetch mysql client info. Used when export-multi-hosts is true.",
+	).Default("config-multi.yml").String()
 	dsn string
-    configMulti *multiHostExporterConfig
+	configMulti *multiHostExporterConfig
 )
 
 // scrapers lists all possible collection methods and if they should be enabled by default.
@@ -223,18 +223,18 @@ func newHandler(metrics collector.Metrics, scrapers []collector.Scraper, logger 
 
 		registry := prometheus.NewRegistry()
 
-        if *multiHostExporter {
-            target := r.URL.Query().Get("target")
-            if target == "" {
-	            http.Error(w, "Target parameter is missing", http.StatusBadRequest)
-		        return
-	        }
-            var err error
-            if dsn, err = configMulti.formDSN(target); err != nil {
-                http.Error(w, err.Error(), http.StatusInternalServerError)
-                return
-            }
-        }
+		if *multiHostExporter {
+			target := r.URL.Query().Get("target")
+			if target == "" {
+				http.Error(w, "Target parameter is missing", http.StatusBadRequest)
+				return
+			}
+			var err error
+			if dsn, err = configMulti.formDSN(target); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
 		registry.MustRegister(collector.New(ctx, dsn, metrics, filteredScrapers, logger))
 
 		gatherers := prometheus.Gatherers{
@@ -286,27 +286,27 @@ func main() {
 	level.Info(logger).Log("msg", "Starting msqyld_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", version.BuildContext())
 
-    if !*multiHostExporter {
-	    dsn = os.Getenv("DATA_SOURCE_NAME")
-	    if len(dsn) == 0 {
-		    var err error
-		    if dsn, err = parseMycnf(*configMycnf); err != nil {
-			    level.Info(logger).Log("msg", "Error parsing my.cnf", "file", *configMycnf, "err", err)
-			    os.Exit(1)
-		    }
-	    }
-    } else {
-        level.Info(logger).Log("msg", "Multi host exporter mode enabled")
-        var err error
-        if configMulti, err = newMultiHostExporterConfig(*multiHostExporterConfigFile); err != nil {
-            level.Info(logger).Log("msg", "Error parsing multi host config", "file", *multiHostExporterConfigFile, "err", err)
-            os.Exit(1)
-        }
-        if err := configMulti.validate(); err != nil {
-            level.Info(logger).Log("msg", err)
-            os.Exit(1)
-        }
-    }
+	if !*multiHostExporter {
+		dsn = os.Getenv("DATA_SOURCE_NAME")
+		if len(dsn) == 0 {
+			var err error
+			if dsn, err = parseMycnf(*configMycnf); err != nil {
+				level.Info(logger).Log("msg", "Error parsing my.cnf", "file", *configMycnf, "err", err)
+				os.Exit(1)
+			}
+		}
+	} else {
+		level.Info(logger).Log("msg", "Multi host exporter mode enabled")
+		var err error
+		if configMulti, err = newMultiHostExporterConfig(*multiHostExporterConfigFile); err != nil {
+			level.Info(logger).Log("msg", "Error parsing multi host config", "file", *multiHostExporterConfigFile, "err", err)
+			os.Exit(1)
+		}
+		if err := configMulti.validate(); err != nil {
+			level.Info(logger).Log("msg", err)
+			os.Exit(1)
+		}
+	}
 
 	// Register only scrapers enabled by flag.
 	enabledScrapers := []collector.Scraper{}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -60,7 +60,16 @@ var (
 		"tls.insecure-skip-verify",
 		"Ignore certificate and server verification when using a tls connection.",
 	).Bool()
+    multiHostExporter = kingpin.Flag(
+        "export-multi-hosts",
+        "Setting it to true enables scraping multiple mysql hosts.",
+    ).Default("false").Bool()
+    multiHostExporterConfigFile = kingpin.Flag(
+        "config-multi-hosts",
+        "Path to yaml config file to fetch mysql client info. Used when export-multi-hosts is true.",
+    ).Default("config-multi.yml").String()
 	dsn string
+    configMulti *multiHostExporterConfig
 )
 
 // scrapers lists all possible collection methods and if they should be enabled by default.
@@ -213,6 +222,19 @@ func newHandler(metrics collector.Metrics, scrapers []collector.Scraper, logger 
 		}
 
 		registry := prometheus.NewRegistry()
+
+        if *multiHostExporter {
+            target := r.URL.Query().Get("target")
+            if target == "" {
+	            http.Error(w, "Target parameter is missing", http.StatusBadRequest)
+		        return
+	        }
+            var err error
+            if dsn, err = configMulti.formDSN(target); err != nil {
+                http.Error(w, err.Error(), http.StatusInternalServerError)
+                return
+            }
+        }
 		registry.MustRegister(collector.New(ctx, dsn, metrics, filteredScrapers, logger))
 
 		gatherers := prometheus.Gatherers{
@@ -264,14 +286,27 @@ func main() {
 	level.Info(logger).Log("msg", "Starting msqyld_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", version.BuildContext())
 
-	dsn = os.Getenv("DATA_SOURCE_NAME")
-	if len(dsn) == 0 {
-		var err error
-		if dsn, err = parseMycnf(*configMycnf); err != nil {
-			level.Info(logger).Log("msg", "Error parsing my.cnf", "file", *configMycnf, "err", err)
-			os.Exit(1)
-		}
-	}
+    if !*multiHostExporter {
+	    dsn = os.Getenv("DATA_SOURCE_NAME")
+	    if len(dsn) == 0 {
+		    var err error
+		    if dsn, err = parseMycnf(*configMycnf); err != nil {
+			    level.Info(logger).Log("msg", "Error parsing my.cnf", "file", *configMycnf, "err", err)
+			    os.Exit(1)
+		    }
+	    }
+    } else {
+        level.Info(logger).Log("msg", "Multi host exporter mode enabled")
+        var err error
+        if configMulti, err = newMultiHostExporterConfig(*multiHostExporterConfigFile); err != nil {
+            level.Info(logger).Log("msg", "Error parsing multi host config", "file", *multiHostExporterConfigFile, "err", err)
+            os.Exit(1)
+        }
+        if err := configMulti.validate(); err != nil {
+            level.Info(logger).Log("msg", err)
+            os.Exit(1)
+        }
+    }
 
 	// Register only scrapers enabled by flag.
 	enabledScrapers := []collector.Scraper{}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -66,10 +66,10 @@ var (
 	).Default("false").Bool()
 	multiHostExporterConfigFile = kingpin.Flag(
 		"config-multi-hosts",
-		"Path to yaml config file to fetch mysql client info. Used when export-multi-hosts is true.",
-	).Default("config-multi.yml").String()
-	dsn string
-	configMulti *multiHostExporterConfig
+		"Path to ini config file to fetch mysql client info. Used when export-multi-hosts is true.",
+	).Default("config-multi.ini").String()
+	dsn         string
+	configMulti *ini.File
 )
 
 // scrapers lists all possible collection methods and if they should be enabled by default.
@@ -230,7 +230,7 @@ func newHandler(metrics collector.Metrics, scrapers []collector.Scraper, logger 
 				return
 			}
 			var err error
-			if dsn, err = configMulti.formDSN(target); err != nil {
+			if dsn, err = formMultiHostExporterDSN(target, configMulti); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
@@ -302,7 +302,7 @@ func main() {
 			level.Info(logger).Log("msg", "Error parsing multi host config", "file", *multiHostExporterConfigFile, "err", err)
 			os.Exit(1)
 		}
-		if err := configMulti.validate(); err != nil {
+		if err := validateMultiHostExporterConfig(configMulti); err != nil {
 			level.Info(logger).Log("msg", err)
 			os.Exit(1)
 		}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -287,13 +287,10 @@ func main() {
 	level.Info(logger).Log("msg", "Build context", version.BuildContext())
 
 	if !*multiHostExporter {
-		dsn = os.Getenv("DATA_SOURCE_NAME")
-		if len(dsn) == 0 {
-			var err error
-			if dsn, err = parseMycnf(*configMycnf); err != nil {
-				level.Info(logger).Log("msg", "Error parsing my.cnf", "file", *configMycnf, "err", err)
-				os.Exit(1)
-			}
+		var err error
+		if dsn, err = parseMycnf(*configMycnf); err != nil {
+			level.Info(logger).Log("msg", "Error parsing my.cnf", "file", *configMycnf, "err", err)
+			os.Exit(1)
 		}
 	} else {
 		level.Info(logger).Log("msg", "Multi host exporter mode enabled")

--- a/test_image_multi_exporter.sh
+++ b/test_image_multi_exporter.sh
@@ -20,7 +20,7 @@ wait_start() {
 }
 
 docker_start() {
-    container_id=$(docker run -d --network mysql-test -e DATA_SOURCE_NAME="root:secret@(mysql-test:3306)/" -p "${port}":"${port}" "${docker_image}")
+    container_id=$(docker run -d --network mysql-test -p "${port}":"${port}" "${docker_image}") --export-multi-hosts --config-multi-hosts=test_single_exporter.cnf
 }
 
 docker_cleanup() {

--- a/test_image_single_exporter.sh
+++ b/test_image_single_exporter.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -exo pipefail
+
+docker_image=$1
+port=$2
+
+container_id=''
+
+wait_start() {
+    for in in {1..10}; do
+        if  /usr/bin/curl -s -m 5 -f "http://localhost:${port}/metrics" > /dev/null; then
+            docker_cleanup
+            exit 0
+        else
+            sleep 1
+        fi
+    done
+
+    exit 1
+}
+
+docker_start() {
+    container_id=$(docker run -d --network mysql-test -p "${port}":"${port}" "${docker_image}") --config.my-cnf=test_single_exporter.cnf
+}
+
+docker_cleanup() {
+    docker kill "${container_id}"
+}
+
+if [[ "$#" -ne 2 ]] ; then
+    echo "Usage: $0 quay.io/prometheus/mysqld-exporter:v0.10.0 9104" >&2
+    exit 1
+fi
+
+docker_start
+wait_start

--- a/test_multi_exporter.cnf
+++ b/test_multi_exporter.cnf
@@ -1,0 +1,7 @@
+
+[client]
+user = foo
+password = foo123
+[client.server1]
+user = bar
+password = bar123

--- a/test_single_exporter.cnf
+++ b/test_single_exporter.cnf
@@ -1,0 +1,6 @@
+[client]
+host=localhost
+port=3306
+socket=/var/run/mysqld/mysqld.sock
+user=foo
+password=bar


### PR DESCRIPTION
Discussion at #452 (comment)

Short summary:
This adds a new flag called export-multi-hosts and allows for passing a yaml file which contains the config related to this mode. Note that this change does not make any changes to the way mysqld_exporter works and as a result it would continue to use the ini format config when working in the non export-multi-hosts mode.